### PR TITLE
Ensure node dependencies are installed before installing sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,6 @@ format:
 	black .
 
 generate_sdk:
+	npm install
 	python sdk_client_script.py
 	npm run generate-client


### PR DESCRIPTION
**Notes:**
- Ran through install instructions, make tool tried to generate openapi sdk client without checking first that the package dependencies were installed. 